### PR TITLE
 Rework CI to remove all secrets and use a private docker container instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt-get install -y make git build-essential clang binutils-mips-linux-gnu gcc-mips-linux-gnu clang-format-14 clang-tidy-14
+          apt-get install -y make git build-essential clang binutils-mips-linux-gnu gcc-mips-linux-gnu clang-format-14 clang-tidy-14
           curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Sync uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_repo:
     # This is a *private* build container.
-    container: ghcr.io/AngheloAlf/drmario64-build:main
+    container: ghcr.io/agheloalf/drmario64-build:main
 
     name: Build repo (${{ matrix.version }})
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_repo:
     # This is a *private* build container.
-    container: ghcr.io/agheloalf/drmario64-build:main
+    container: ghcr.io/angheloalf/drmario64-build:main
 
     name: Build repo (${{ matrix.version }})
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,15 @@
 name: Build
 
 # Build on every branch push, tag push, and pull request change:
-on: [push, pull_request_target]
+on:
+  push:
+  pull_request:
 
 jobs:
   build_repo:
+    # This is a *private* build container.
+    container: ghcr.io/AngheloAlf/drmario64-build:main
+
     name: Build repo (${{ matrix.version }})
     runs-on: ubuntu-latest
 
@@ -26,14 +31,8 @@ jobs:
         run: |
           uv sync
 
-      - name: Get extra dependencies
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ secrets.SECRETREPO }}
-          token: ${{ secrets.SECRETTOKEN }}
-          path: deps_repo
       - name: Get the dependency
-        run: cp deps_repo/drmario64/baserom.${{ matrix.version }}.z64 config/${{ matrix.version }}/baserom.${{ matrix.version }}.z64
+        run: cp /orig/${{ matrix.version }}/baserom.${{ matrix.version }}.z64 config/${{ matrix.version }}/baserom.${{ matrix.version }}.z64
 
       - name: Setup
         run: make setup -j $(nproc) VERSION=${{ matrix.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          apt-get install -y make git build-essential clang binutils-mips-linux-gnu gcc-mips-linux-gnu clang-format-14 clang-tidy-14
+          apt-get install -y make git build-essential wget clang binutils-mips-linux-gnu gcc-mips-linux-gnu clang-format-14 clang-tidy-14
           curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Sync uv

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The build process has the following package requirements:
 * make
 * git
 * build-essential
+* wget
 * clang
 * binutils-mips-linux-gnu
 * gcc-mips-linux-gnu
@@ -40,8 +41,7 @@ with the following commands:
 
 ```bash
 sudo apt update
-sudo apt install make git build-essential clang binutils-mips-linux-gnu gcc-mips-linux-gnu
-sudo apt install make git build-essential binutils-mips-linux-gnu
+sudo apt install make git build-essential wget clang binutils-mips-linux-gnu gcc-mips-linux-gnu
 ```
 
 ### `uv`


### PR DESCRIPTION
Shoutouts to @encounter and the GC/Wii community for the idea.

## What is it?

This PR reworks the CI so it no longer requires GHA secrets at all to be able to check the build still matches, generate reports, etc.

I simply followed encounter's guide for setting up github actions <https://github.com/encounter/dtk-template/blob/main/docs/github_actions.md> ([permalink](https://github.com/encounter/dtk-template/blob/d97c36e113d5afba46b38b7aab9d9b2fee3c13d6/docs/github_actions.md)) and adapted it to my needs.
The only real changes I did from encounter's dtk-template-build repo is that I changed the image to use ubuntu instead of alpine and removed the compilers since this repo downloads on its own already and I wanted changes to be minimal.
<img width="1249" height="466" alt="image" src="https://github.com/user-attachments/assets/6cbd7c9a-50dd-4c11-b16a-7c24de78cbb8" />


Remember to check you have correctly configured the "Approval for running PRs" setting in your repo

<img width="1010" height="563" alt="image" src="https://github.com/user-attachments/assets/461140c7-c397-413e-b1b4-de295db738d7" />

<img width="824" height="386" alt="image" src="https://github.com/user-attachments/assets/292fdaf1-87a2-49ec-823b-3a199492ae9c" />



## Why change the CI approach?

The old approach worked fineish, but it had one terrible problem: it required GHA `pull_request_target`.

The main isue with `pull_request_target` is pretty insecure. It skips security measures like not running the CI automatically for first-time contributors. This makes any repository using this approach a target for automated pwn attacks trying to steal GHA secrets.
Even if the secrets that a decomp repository has are not that important, having to deal with this and check what the attacker did is pretty bad.

This approach removes the `pull_request_target` from any GHA yaml, making a lot less likely to be attacked by bad actors.

Finally, I feel like this approach is simpler, there's no need to worry about GHA secrets and such.

## Are there other approaches?

Yeah, you can configure CI to only run if a PR has a specific label.

You can even do something more sophisticated like what the [Pilotwings64Decomp](https://github.com/gcsmith/Pilotwings64Decomp) team does, which consists on a multi step yaml that implements a way to prevent the exposure of secrets to attackers by using a pretty elaborated setup.

This approach is [documented here](https://github.com/gcsmith/example-secrets-flow).

I decided to not use this approach because it felt way too complicated.
Their approach still requires at least one yaml file with `pull_request_target`, making it likely for bad actors to still want to target the repository, even if they can't get past their security measures.
The docker approach removes the need for GHA secrets, and completely removes all the `pull_request_target` from CI, making less likely for bad actors to even open a PR in the first place.

